### PR TITLE
check if the deploy directory is empty or not

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,6 +24,11 @@ while : ; do
 	fi
 done
 
+if ! find "$deploy_directory" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
+	echo "Deploy dir '$deploy_directory' is empty, please make sure it has content." >&2
+	exit 1
+fi
+
 #echo expanded commands as they are executed (for debugging)
 function enable_expanded_output {
 	if [ $verbose ]; then


### PR DESCRIPTION
An empty deploy directory would generate unexpected results:
* It may wipe out gh-pages branch, usually we don't expect that.
* In a newly cloned repo, if the folder does not exist, script would
  get error like:
  fatal: This operation must be run in a work tree
  The error is from line "git --work-tree "$deploy_directory" reset
  --mixed --quiet"
* If remote branch does not exist, 'deploy.sh -s' would also get wrong
  result.

To improve it, check if the directory is not empty in the beginning.